### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "rpass"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpass"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Arinze Chianumba"]
 edition = "2024"
 description = "A (symmetric/asymmetric) GPG-based secrets manager for the CLI"


### PR DESCRIPTION



## 🤖 New release

* `rpass`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).