### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.6](https://github.com/achianumba/rpass/compare/v0.1.5...v0.1.6) - 2025-08-23
+
+### Added
+
+- git, copy, and move

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "rpass"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpass"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Arinze Chianumba"]
 edition = "2024"
 description = "A (symmetric/asymmetric) GPG-based secrets manager for the CLI"


### PR DESCRIPTION



## 🤖 New release

* `rpass`: 0.1.5 -> 0.1.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/achianumba/rpass/compare/v0.1.5...v0.1.6) - 2025-08-23

### Added

- git, copy, and move
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).