### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/achianumba/rpass/compare/v0.1.6...v0.1.7) - 2025-08-24
+
+### Added
+
+- release on deps update
+
+### Fixed
+
+- release_commits regex
+
+### Other
+
+- Merge pull request #20 from achianumba/update-deps
+- *(deps)* update toml
+- update docs
+
 ## [0.1.6](https://github.com/achianumba/rpass/compare/v0.1.5...v0.1.6) - 2025-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,7 +691,7 @@ dependencies = [
 
 [[package]]
 name = "rpass"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpass"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Arinze Chianumba"]
 edition = "2024"
 description = "A (symmetric/asymmetric) GPG-based secrets manager for the CLI"


### PR DESCRIPTION



## 🤖 New release

* `rpass`: 0.1.6 -> 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/achianumba/rpass/compare/v0.1.6...v0.1.7) - 2025-08-24

### Added

- release on deps update

### Fixed

- release_commits regex

### Other

- Merge pull request #20 from achianumba/update-deps
- *(deps)* update toml
- update docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).