### PR TITLE
chore: release v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/achianumba/rpass/compare/v0.1.7...v0.1.8) - 2025-08-27
+
+### Added
+
+- decrypt entries directly with gpg cli
+- encrypt data through an io pipe to/from gpg
+- improve user-friendly std output
+
+### Fixed
+
+- use of undeclared type 'Instant'
+
+### Other
+
+- update docs
+
 ## [0.1.7](https://github.com/achianumba/rpass/compare/v0.1.6...v0.1.7) - 2025-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "rpass"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpass"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Arinze Chianumba"]
 edition = "2024"
 description = "A (symmetric/asymmetric) GPG-based secrets manager for the CLI"


### PR DESCRIPTION



## 🤖 New release

* `rpass`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.8](https://github.com/achianumba/rpass/compare/v0.1.7...v0.1.8) - 2025-08-27

### Added

- decrypt entries directly with gpg cli
- encrypt data through an io pipe to/from gpg
- improve user-friendly std output

### Fixed

- use of undeclared type 'Instant'

### Other

- update docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).