### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/achianumba/rpass/compare/v0.1.8...v0.1.9) - 2025-10-16
+
+### Other
+
+- *(deps)* drop unnecessary gpg dependencies
+- manually rigger release
+
 ## [0.1.8](https://github.com/achianumba/rpass/compare/v0.1.7...v0.1.8) - 2025-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 
 [[package]]
 name = "rpass"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "arboard",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpass"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Arinze Chianumba"]
 edition = "2024"
 description = "A (symmetric/asymmetric) GPG-based secrets manager for the CLI"


### PR DESCRIPTION



## 🤖 New release

* `rpass`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/achianumba/rpass/compare/v0.1.8...v0.1.9) - 2025-10-16

### Other

- *(deps)* drop unnecessary gpg dependencies
- manually rigger release
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).